### PR TITLE
nuiui-cat文档的快速上手、NutBottom报错问题和NutStarbrand问题

### DIFF
--- a/src/docs/start.md
+++ b/src/docs/start.md
@@ -23,39 +23,43 @@ npm i @nutui/nutui-cat -S
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- 引入样式 -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@nutui/nutui-cat/dist/nutui-cat.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@nutui/nutui-cat/dist/nutui-cat.css"
+    />
     <!-- 引入Vue -->
-    <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2"></script>
     <!-- 引入NutUI组件库 -->
     <script src="https://cdn.jsdelivr.net/npm/@nutui/nutui-cat/dist/nutui-cat.umd.js"></script>
   </head>
   <body>
-    <div id="app">
-        
-    </div>
+    <div id="app"></div>
     <script>
+      Vue.use(nutcat)
       // 在 #app 标签下渲染一个文本组件
-      const app = Vue.createApp({
+      const app = new Vue({
         template: `
         <NutText>我是标题</NutText>
         `,
-      });
-      app.use(nutui);
-      app.mount("#app");
+      })
+      app.$mount('#app')
     </script>
   </body>
 </html>
+
 ```
 
 > 在页面中直接引入，将无法使用 **主题定制** 等功能。我们推荐使用 *NPM* 或 *YARN* 方式安装，不推荐在页面中直接引入的用法
 #### NPM 使用示例
 
 ```javascript
-import { createApp } from "vue";
 import App from "./App.vue";
 import NutCat from "@nutui/nutui-cat";
 import "@nutui/nutui-cat/dist/nutui-cat.css";
-createApp(App).use(NutCat).mount("#app");
+Vue.use(NutCat)
+new Vue({
+  render: (h) => h(App),
+}).$mount('#app')
 ```
 
 > 注意：这种方式将会导入所有组件

--- a/src/packages/bottom/index.vue
+++ b/src/packages/bottom/index.vue
@@ -14,7 +14,7 @@
             <img
               :src="
                 item.name == activeName
-                  ? $get('comments.0', item)
+                  ? item.comments[0]
                   : item.pictureUrl
               "
             />

--- a/src/packages/starbrand/index.vue
+++ b/src/packages/starbrand/index.vue
@@ -76,7 +76,7 @@ export default create({
           freeModeMomentum: false, // 取消惯性
           on: {
             click(swiper:any) {
-              that.$emit("callback", swiper);
+              that.$emit("callback", item[index]);
             }
           }
         });


### PR DESCRIPTION
①nuiui-cat目前技术栈是 Vue 2.0。
nuiui-cat文档的“快速上手”的“CDN 安装使用示例”和“NPM 使用示例”的代码用的是
Vue3，应该改为Vue2。
②解决使用NutBottom报错问题，TypeError: t.$get is not a function
③NutStarbrand按照文档callback事件应该返回“当前item的数据”，而非“swiper“